### PR TITLE
Module 1 light updates

### DIFF
--- a/src/components/ToolCard.vue
+++ b/src/components/ToolCard.vue
@@ -141,9 +141,9 @@ const title = computed(() => {
     return props.titleOverride;
   }
   if (inBottomToolSlot) {
-    return 'Spectrum 2';
+    return 'Source 2';
   }
-  return 'Spectrum 1';
+  return 'Source 1';
 });
 
 // Refactored a lot of this setup function into composables, due to complexity

--- a/src/layouts/LightLayout.vue
+++ b/src/layouts/LightLayout.vue
@@ -7,8 +7,8 @@
             <SectionNavItem to="/light/introduction">
               Introduction
             </SectionNavItem>
-            <SectionNavItem to="/light/predictions">
-              Make a Prediction
+            <SectionNavItem to="/light/color-filters">
+              Color Filters
             </SectionNavItem>
             <SectionNavItem to="/light/photons">
               Photons and Color

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,8 @@ import NotFound from './pages/NotFound.vue';
 import ExoplanetsComparing1 from './pages/Exoplanets/ExoplanetsComparing1.vue';
 import ExoplanetsComparing2 from './pages/Exoplanets/ExoplanetsComparing2.vue';
 import ExoplanetsProposal from './pages/Exoplanets/ExoplanetsProposal.vue';
-import LightPredictions from './pages/Light/LightPredictions.vue';
+import ColorFilterPrediction from './pages/Light/LightFilterPrediction.vue';
+import ColorFilterInvestigation from './pages/Light/LightFilterInvestigation.vue';
 import LightPhotons from './pages/Light/LightPhotons.vue';
 import AttributionsPage from './pages/AttributionsPage.vue';
 import LightMixing from './pages/Light/LightMixing.vue';
@@ -97,7 +98,14 @@ const routes: RouteRecordRaw[] = [
     redirect: '/light/introduction',
     children: [
       { path: 'introduction', component: LightIntroduction },
-      { path: 'predictions', component: LightPredictions },
+      {
+        path: 'color-filters',
+        redirect: '/light/color-filters/predictions',
+        children: [
+          { path: 'predictions', component: ColorFilterPrediction },
+          { path: 'investigation', component: ColorFilterInvestigation },
+        ],
+      },
       { path: 'photons', component: LightPhotons },
       { path: 'mixing', component: LightMixing },
       { path: 'behaviors', component: LightBehaviors },

--- a/src/pages/Light/LightBehaviors.vue
+++ b/src/pages/Light/LightBehaviors.vue
@@ -9,11 +9,11 @@
       <InstructionRow row-type="Notebook">
         <template #steps>
           <InstructionStep>
-            In <em>Part A</em> of the <em>Behaviors of Light</em> section, label
+            In <em>Part 1</em> of the <em>Behaviors of Light</em> section, label
             the diagram with the key behaviors of light.
           </InstructionStep>
           <InstructionStep>
-            Answer the questions in <em>Part B</em>.
+            Answer the questions in <em>Part 2</em>.
           </InstructionStep>
         </template>
       </InstructionRow>

--- a/src/pages/Light/LightFilterInvestigation.vue
+++ b/src/pages/Light/LightFilterInvestigation.vue
@@ -1,0 +1,61 @@
+<template>
+  <LightLayout>
+    <ChallengeCard>
+      <template #top>
+        <InstructionHeader
+          >Color Filters Part 2: Investigation</InstructionHeader
+        >
+        <InstructionRow row-type="Investigate">
+          <span class="challenge-emphasis"> NOW </span> look through the gels,
+          and note how what you see compares with your predictions.
+        </InstructionRow>
+        <InstructionRow row-type="Notebook">
+          <template #steps>
+            <InstructionStep>
+              What did you actually see when you looked through the red gel? How
+              did it compare with your prediction?
+            </InstructionStep>
+            <InstructionStep>
+              Describe what you think is happening, given the colors you saw
+              through the red gel.
+            </InstructionStep>
+            <InstructionStep>
+              Discuss your ideas with your partner. What ideas did your partner
+              add that seemed helpful?
+            </InstructionStep>
+          </template>
+        </InstructionRow>
+      </template>
+      <template #middle>
+        <div class="bg-gen-black">
+          <img
+            src="/src/assets/2x/RGB circles@2x.webp"
+            alt="Intersecting red, green, and blue circles of light"
+            class="d-block mx-auto"
+            style="max-width: 575px"
+          />
+        </div>
+      </template>
+      <template #bottom>
+        <LeftRightGroup>
+          <template #left>
+            <NextPrevButton direction="prev" light to="predictions">
+              previous part
+            </NextPrevButton>
+          </template>
+          <template #right>
+            <NextPrevButton direction="next" light to="../photons">
+              next section
+            </NextPrevButton>
+          </template>
+        </LeftRightGroup>
+      </template>
+    </ChallengeCard>
+  </LightLayout>
+</template>
+
+<script setup lang="ts">
+import { useSpecLabHead } from '@/utils/locationUtils';
+
+useSpecLabHead('Make a Prediction', 'Light');
+</script>

--- a/src/pages/Light/LightFilterPrediction.vue
+++ b/src/pages/Light/LightFilterPrediction.vue
@@ -2,7 +2,7 @@
   <LightLayout>
     <ChallengeCard>
       <template #top>
-        <InstructionHeader>Make a Prediction</InstructionHeader>
+        <InstructionHeader>Color Filters Part 1: Predictions</InstructionHeader>
         <InstructionRow row-type="Investigate">
           <span class="challenge-emphasis"> Without using any gels</span>,
           examine the image below and consider:
@@ -14,7 +14,7 @@
           </template>
         </InstructionRow>
         <InstructionRow row-type="Notebook">
-          Write your prediction in the chart, noting the predicted color for
+          Write your predictions in the chart, noting the predicted color for
           each section of the three circles.
         </InstructionRow>
       </template>
@@ -31,13 +31,17 @@
       <template #bottom>
         <LeftRightGroup>
           <template #left>
-            <NextPrevButton direction="prev" light to="introduction">
+            <NextPrevButton direction="prev" light to="/light/introduction">
               previous section
             </NextPrevButton>
           </template>
           <template #right>
-            <NextPrevButton direction="next" light to="photons">
-              next section
+            <NextPrevButton
+              direction="next"
+              light
+              to="/light/color-filters/investigation"
+            >
+              next part
             </NextPrevButton>
           </template>
         </LeftRightGroup>

--- a/src/pages/Light/LightIntroduction.vue
+++ b/src/pages/Light/LightIntroduction.vue
@@ -1,6 +1,6 @@
 <template>
   <LightLayout>
-    <CardWithSlideshow :slide-order="slideOrder" next-section="predictions">
+    <CardWithSlideshow :slide-order="slideOrder" next-section="color-filters">
       <InstructionHeader>Light in Different Fields</InstructionHeader>
       <InstructionRow row-type="Slideshow">
         Step through this slideshow for an overview of how different fields use

--- a/src/pages/Light/LightMixing.vue
+++ b/src/pages/Light/LightMixing.vue
@@ -10,7 +10,7 @@
         <InstructionRow row-type="Notebook">
           <template #steps>
             <InstructionStep>
-              Follow instructions in <em>Part A</em> of the
+              Follow instructions in <em>Part 1</em> of the
               <em>Color Mixing</em> section.
             </InstructionStep>
             <InstructionStep>
@@ -18,7 +18,7 @@
               color.
             </InstructionStep>
             <InstructionStep>
-              Answer the questions in <em>Part B</em>
+              Answer the questions in <em>Part 2</em>
             </InstructionStep>
           </template>
         </InstructionRow>

--- a/src/pages/Light/LightPhotons.vue
+++ b/src/pages/Light/LightPhotons.vue
@@ -10,11 +10,11 @@
         <InstructionRow row-type="Notebook">
           <template #steps>
             <InstructionStep>
-              Follow instructions in <em>Part A</em> of the
+              Follow instructions in <em>Part 1</em> of the
               <em>Photons and Color</em> section.
             </InstructionStep>
             <InstructionStep>
-              Answer the questions in <em>Part B</em>.
+              Answer the questions in <em>Part 2</em>.
             </InstructionStep>
           </template>
         </InstructionRow>


### PR DESCRIPTION
This aligns the online tool with the notebook.
- Split "Predictions" into 2 parts - "Color Filters/predictions" & "Color Filters/investigation"
- Use Part 1/Part 2 throughout instead of Part A/Part B

Also:
- I updated the toolcard to use "source" instead of "spectrum" but I wasn't able to figure out how to remove the numbering when there is only 1 tool. @VanessaPhippsCfa, can you please make that update in a future branch? Thanks!